### PR TITLE
Adding the capability to override the == operator

### DIFF
--- a/lib/drag_and_drop_item.dart
+++ b/lib/drag_and_drop_item.dart
@@ -18,4 +18,8 @@ class DragAndDropItem implements DragAndDropInterface {
     this.feedbackWidget,
     this.canDrag = true,
   });
+  @override
+  bool operator ==(other) {
+    return other is DragAndDropItem && other.child == child;
+  }
 }


### PR DESCRIPTION
With this change it will delegate the == to the child so that you can override it and it will avoid duplicated items.
An example of this issue: You have two lists a food menu that you'd like to modify with current food and a food list. as the food menu  list children has been pre-generated from DB the DragAndDropItem are different from food list, so you can drag an existing item and it will create duplications. If you delegate the == operator to the DragAndDropItem child the user can control how two objects are equals, if by reference or by something more complex like foodId